### PR TITLE
Remove update (requires sudo prompt)

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -124,6 +124,3 @@ bind -s 'set completion-ignore-case on'
 
 # Start ssh-agent and prompt for password
 eval `ssh-agent` && ssh-add ~/.ssh/id_ed25519
-
-# Check for and install updates
-sudo apt update && sudo apt upgrade -y


### PR DESCRIPTION
## Description

While I run an auto update every time, this is just a one-liner I can do once a day on my own.

## Changed
- removed `sudo apt update` command after starting the ssh agent