### PR TITLE
Alias python as python3 in bash_aliases

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,0 +1,1 @@
+alias python='python3'


### PR DESCRIPTION
## Description

Added the alias `python` for `python3`.